### PR TITLE
Add CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
   build_and_tests:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
       # Setup Java & Python
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@3f07048e3d294f56e9b90ac5ea2c6f74e9ad0f98 # v3.10.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Checkout icat-authentication
-        uses: actions/checkout@v2
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Run Build
         run: mvn install -DskipTests

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,25 @@
+name: CI Build
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+  build_and_tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        java: [ '8', '11' ]
+    steps:
+      # Setup Java & Python
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+
+      - name: Checkout icat-autnetication
+        uses: actions/checkout@v2
+
+      - name: Run Build
+        run: mvn install -DskipTests

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -28,7 +28,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Checkout icat-autnetication
+      - name: Checkout icat-authentication
         uses: actions/checkout@v2
 
       - name: Run Build

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,6 +18,14 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Checkout icat-autnetication
         uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# icat_authentication
+
+
+[![Build Status](https://github.com/icatproject/icat.authentication/workflows/CI%20Build/badge.svg?branch=master)](https://github.com/icatproject/icat.authentication/actions?query=workflow%3A%22CI+Build%22)


### PR DESCRIPTION
Adds CI using GitHub Actions and a status badge to the README. The status badge will start working once this PR gets merged into `master`, but this is the status badge for this branch to prove that it works:

[![Build Status](https://github.com/icatproject/icat.authentication/workflows/CI%20Build/badge.svg?branch=add-ci)](https://github.com/icatproject/icat.authentication/actions?query=workflow%3A%22CI+Build%22)

- [ ] Should run maven build
- [ ] Java 8 CI should pass
- [ ] Java 11 CI should pass