### PR TITLE
Upgrade to JakartaEE 10 API for compatibility with Payara 6

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   build_and_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        java: [ '8', '11' ]
+        java: [ '11', '17' ]
     steps:
-      # Setup Java & Python
+      # Setup Java
       - name: Setup Java
         uses: actions/setup-java@3f07048e3d294f56e9b90ac5ea2c6f74e9ad0f98 # v3.10.0
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,10 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax</groupId>
-			<artifactId>javaee-api</artifactId>
-			<version>7.0</version>
+			<groupId>jakarta.platform</groupId>
+			<artifactId>jakarta.jakartaee-api</artifactId>
+			<version>9.1.0</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>icat.authentication</artifactId>
 	<packaging>jar</packaging>
 	<description>Interface need by authentication plugins</description>
-	<version>5.0.0-SNAPSHOT</version>
+	<version>5.0.0</version>
 	<name>ICAT Authentication</name>
 
 	<properties>
@@ -28,7 +28,7 @@
 		<connection>scm:git:${gitUrl}.git</connection>
 		<developerConnection>scm:git:${gitUrl}.git</developerConnection>
 		<url>${gitUrl}</url>
-		<tag>HEAD</tag>
+		<tag>v5.0.0</tag>
 	</scm>
 
 	<issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>icat.authentication</artifactId>
 	<packaging>jar</packaging>
 	<description>Interface need by authentication plugins</description>
-	<version>5.0.0</version>
+	<version>5.0.1-SNAPSHOT</version>
 	<name>ICAT Authentication</name>
 
 	<properties>
@@ -28,7 +28,7 @@
 		<connection>scm:git:${gitUrl}.git</connection>
 		<developerConnection>scm:git:${gitUrl}.git</developerConnection>
 		<url>${gitUrl}</url>
-		<tag>v5.0.0</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>jakarta.platform</groupId>
 			<artifactId>jakarta.jakartaee-api</artifactId>
-			<version>9.1.0</version>
+			<version>10.0.0</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>icat.authentication</artifactId>
 	<packaging>jar</packaging>
 	<description>Interface need by authentication plugins</description>
-	<version>4.6.1-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
 	<name>ICAT Authentication</name>
 
 	<properties>
@@ -98,10 +98,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.10.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<release>11</release>
 				</configuration>
 			</plugin>
 

--- a/src/main/java/org/icatproject/authentication/Authenticator.java
+++ b/src/main/java/org/icatproject/authentication/Authenticator.java
@@ -2,7 +2,7 @@ package org.icatproject.authentication;
 
 import java.util.Map;
 
-import javax.ejb.Remote;
+import jakarta.ejb.Remote;
 
 import org.icatproject.core.IcatException;
 

--- a/src/main/java/org/icatproject/core/IcatException.java
+++ b/src/main/java/org/icatproject/core/IcatException.java
@@ -1,7 +1,7 @@
 package org.icatproject.core;
 
-import javax.ejb.ApplicationException;
-import javax.ws.rs.core.Response.Status;
+import jakarta.ejb.ApplicationException;
+import jakarta.ws.rs.core.Response.Status;
 
 @SuppressWarnings("serial")
 @ApplicationException(rollback = true)


### PR DESCRIPTION
Changes the imports of JavaEE classes in the `javax` namespace to the `jakarta` namespace, and increases the Java requirement to version 11 since that is the minimum supported by Jakarta EE 10. These are both breaking changes so this is a new major version.

This has already been released as version 5.0.0.